### PR TITLE
Refactored buildImageName, changed docker build to use it

### DIFF
--- a/src/factories/buildImageName.js
+++ b/src/factories/buildImageName.js
@@ -2,17 +2,9 @@
 
 const _ = require('lodash');
 
-const optionMap = {
-  registry: value => `${value}/`,
-  image: value => `${value}`,
-  tag: value => `:${value}`
-};
-
 module.exports = (config) => {
-  let options = _.pick(config, 'registry', 'image', 'tag');
-  let optionString = _.map(options, (value, key) => {
-    if(!_.has(optionMap, key))  throw new Error(`Cannot find ${key} in optionBuilders`);
-    else                        return optionMap[key](value);
-  }).join('');
-  return optionString;
-};
+  const registry = config.registry ? `${config.registry}/` : '';
+  const image = config.image || '';
+  const tag = config.tag ? `:${config.tag}` : '';
+  return `${registry}${image}${tag}`;
+}

--- a/src/factories/docker/build.js
+++ b/src/factories/docker/build.js
@@ -4,6 +4,7 @@
 
 const _ = require('lodash');
 const buildCommand = require('../buildCommand');
+const buildImageName = require('../buildImageName');
 
 const executable = "docker build"
 
@@ -18,7 +19,7 @@ const optionMap = {
   force_rm:   ()      => '--force-rm',
   quiet:      ()      => '--q',
   tags:       values  => _.map(
-                          values, item => `-t ${item}`)
+                          values, item => `-t ${buildImageName(item)}`)
                           .join(" ")
 };
 

--- a/test/commands/parse.spec.js
+++ b/test/commands/parse.spec.js
@@ -11,7 +11,7 @@ describe('YAML-to-commands parser', () => {
   let tests = [
     {
       key: 'basic',
-      expected: [{ command: 'docker build -t usher .', settings: {}}]
+      expected: [{ command: 'docker build -t usher:test .', settings: {}}]
     },
     {
       key: 'custom',

--- a/test/factories/docker/build.spec.js
+++ b/test/factories/docker/build.spec.js
@@ -42,7 +42,7 @@ describe('Docker Build Command', () => {
       expected: "docker build --q ."
     },
     {
-      options: { tags: [ 'project:123', 'project:latest' ] },
+      options: { tags: [ {image:'project', tag:'123'}, {image:'project', tag:'latest'} ] },
       expected: "docker build -t project:123 -t project:latest ."
     },
     {
@@ -54,7 +54,7 @@ describe('Docker Build Command', () => {
   tests.forEach( (test) => {
     it(`should make ==> ${test.expected}`, () => {
       var command = build(test.options);
-      expect(test.expected).to.equal(command);
+      expect(command).to.equal(test.expected);
     });
   });
 });

--- a/test/factories/docker/pull.spec.js
+++ b/test/factories/docker/pull.spec.js
@@ -5,24 +5,12 @@ describe('Docker Pull Command', () => {
 
   var tests = [
     {
-      options: { tag: "master" },
-      expected: "docker pull"
-    },
-    {
       options: { image: "findmypast/usher" },
       expected: "docker pull findmypast/usher"
     },
     {
       options: { tag: "master", image: "findmypast/usher" },
       expected: "docker pull findmypast/usher:master"
-    },
-    {
-      options: { registry: "docker-registry.example.com" },
-      expected: "docker pull"
-    },
-    {
-      options: { registry: "docker-registry.example.com", tag: "master" },
-      expected: "docker pull"
     },
     {
       options: { image: "findmypast/usher", registry: "docker-registry.example.com" },
@@ -53,7 +41,7 @@ describe('Docker Pull Command', () => {
   tests.forEach( (test) => {
     it(`should make ==> ${test.expected}`, () => {
       var command = build(test.options);
-      expect(test.expected).to.equal(command);
+      expect(command).to.equal(test.expected);
     });
   });
 });

--- a/test/factories/docker/push.spec.js
+++ b/test/factories/docker/push.spec.js
@@ -5,24 +5,12 @@ describe('Docker Push Command', () => {
 
   var tests = [
     {
-      options: { tag: "master" },
-      expected: "docker push"
-    },
-    {
       options: { image: "findmypast/usher" },
       expected: "docker push findmypast/usher"
     },
     {
       options: { tag: "master", image: "findmypast/usher" },
       expected: "docker push findmypast/usher:master"
-    },
-    {
-      options: { registry: "docker-registry.example.com" },
-      expected: "docker push"
-    },
-    {
-      options: { registry: "docker-registry.example.com", tag: "master" },
-      expected: "docker push"
     },
     {
       options: { image: "findmypast/usher", registry: "docker-registry.example.com" },
@@ -45,7 +33,7 @@ describe('Docker Push Command', () => {
   tests.forEach( (test) => {
     it(`should make ==> ${test.expected}`, () => {
       var command = build(test.options);
-      expect(test.expected).to.equal(command);
+      expect(command).to.equal(test.expected);
     });
   });
 });

--- a/test/test.usher.yml
+++ b/test/test.usher.yml
@@ -2,7 +2,8 @@
 basic:
   cmd: docker build
   tags:
-    - usher
+    - image: usher
+      tag: test
 
 custom:
   cmd: do thing
@@ -10,7 +11,7 @@ custom:
 sequence:
   - cmd: docker build
     tags:
-      - usher
+      - image: usher
   - cmd: do thing
 
 with_settings:


### PR DESCRIPTION
Simplfying buildImageName to use a templating approach.

Docker build factory now uses build image name for tags.

https://trello.com/c/b8AItTjR/241-usher
