### PR TITLE
Local node bins

### DIFF
--- a/.usher.yml
+++ b/.usher.yml
@@ -10,7 +10,7 @@ tasks:
     - cmd: docker push <%=registry%>/<%=image%>:<%=version%>
 
   test:
-    - cmd: docker run --name usher-test-runner --rm <%=registry%>/<%=image%>:<%=version%> npm test
+    - cmd: docker run --name usher-test-runner --rm <%=registry%>/<%=image%>:<%=version%> npm test:ci
 
   publish:
     - cmd: docker run -e NPM_USER -e NPM_PASSWORD -e NPM_EMAIL --name usher-publisher --rm <%=registry%>/<%=image%>:<%=version%> npm run publish-to-npm

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "commander": "^2.9.0",
     "js-yaml": "^3.5.5",
     "lodash": "^4.6.1",
+    "npm-run": "^3.0.0",
     "winston": "^2.2.0"
   },
   "devDependencies": {

--- a/src/modules/task-runner.js
+++ b/src/modules/task-runner.js
@@ -3,7 +3,7 @@
 const _ = require('lodash');
 const logger = require('winston');
 
-let spawnSync = require('child_process').spawnSync;
+let spawnSync = require('npm-run').spawnSync;
 
 class TaskRunner {
   constructor(task, vars) {


### PR DESCRIPTION
- Usher can now run local node binaries (i.e. installed by the project usher is deploying)
- Needed for twoface and all future plugins
- https://trello.com/c/MFFH3yRC/297-usher-can-run-locally-installed-npm-binaries
