### PR TITLE
Ensured command errors are re-thrown to the top level so app crashes

### DIFF
--- a/src/modules/task-runner.js
+++ b/src/modules/task-runner.js
@@ -29,11 +29,14 @@ class TaskRunner {
       this.vars[command.register] = result.stdout;
     }
 
-    return this.shouldExecutionContinue(result, command);
+    if(this.shouldExecutionContinue(result, command)) {
+      return true;
+    }
+    throw result.error;
   }
 
   shouldExecutionContinue(result, command) {
-    return result.status === 0 || command.ignore_errors || false;
+    return result.status === 0 || command.ignore_errors;
   }
 
   expandTokens(command) {

--- a/test/commands-from-yaml.spec.js
+++ b/test/commands-from-yaml.spec.js
@@ -119,15 +119,16 @@ describe('Given a YAML file run command execution', () => {
     }));
 
   it(`Should not continue to execute a sequence of commands when an error is returned`, ()=> {
+    const expectedError = new Error('Test error!');
     spawnSyncStub.returns({
       status: 1,
-      error: new Error('Test error!')
+      error: expectedError
     });
 
     const test = _.find(tests, {key: 'build_seq'});
     const expected = test.expected[0];
 
-    run(test.key, test.cmdArgs, {filepath:filename});
+    expect(() => run(test.key, test.cmdArgs, {filepath:filename})).to.throw(expectedError);
     expect(spawnSyncStub).to.have.been.calledWith(expected.executable, expected.args, expected.options);
     expect(spawnSyncStub).to.have.been.calledOnce;
   })

--- a/test/test.usher.yml
+++ b/test/test.usher.yml
@@ -25,6 +25,7 @@ tasks:
     - cmd: docker rm -f <%=image%>-local
       ignore_errors: true
     - cmd: docker build --force-rm -t <%=registry%>/<%=image%>:<%=version%> .
+      ignore_errors: true
 
   pass_value_to_next_command:
     - cmd: twoface -H <%=host%> -b <%=blue_tag%> -g <%=green_tag%> peek


### PR DESCRIPTION
Found that usher exits with code 0 even when one of the commands failed. Made changes to re-throw the error inside usher so it crashes with the correct info. 
