### PR TITLE
Process should inherit env vars even when env is set in options

### DIFF
--- a/src/modules/task-runner.js
+++ b/src/modules/task-runner.js
@@ -53,7 +53,7 @@ class TaskRunner {
   }
 
   buildSpawnOptions(env) {
-    return !_.isEmpty(env) ? { env: env, stdio: 'inherit' } : { stdio: 'inherit' };
+    return !_.isEmpty(env) ? { env: _.merge(env, process.env), stdio: 'inherit' } : { stdio: 'inherit' };
   }
 };
 


### PR DESCRIPTION
- This was causing mysterious failed builds on the agents
- They were very spooky, just ENOENT with no output :ghost: 
