### PR TITLE
Fix command variable piping

### DIFF
--- a/src/modules/task-runner.js
+++ b/src/modules/task-runner.js
@@ -19,7 +19,7 @@ class TaskRunner {
     if(!command.cmd) throw new Error('Command not defined')
     const parsedCommand = this.expandTokens(command.cmd).split(" ");
     const parsedEnv = this.resolveKeyValuePairs(command.environment);
-    const spawnOptions = this.buildSpawnOptions(parsedEnv)
+    const spawnOptions = this.buildSpawnOptions(command, parsedEnv)
 
     logger.info(`Executing command : ${parsedCommand.join(" ")}`);
 
@@ -52,8 +52,16 @@ class TaskRunner {
     return hashed;
   }
 
-  buildSpawnOptions(env) {
-    return !_.isEmpty(env) ? { env: _.merge(env, process.env), stdio: 'inherit' } : { stdio: 'inherit' };
+  buildSpawnOptions(command, env) {
+    const stdio = command.register ? "pipe" : "inherit";
+    let opts = {
+      stdio: stdio
+    };
+
+    if(!_.isEmpty(env)) {
+      opts.env = _.merge(env, process.env);
+    }
+    return opts;
   }
 };
 

--- a/src/modules/task-runner.js
+++ b/src/modules/task-runner.js
@@ -25,8 +25,10 @@ class TaskRunner {
 
     const result = spawnSync(parsedCommand[0], _.tail(parsedCommand), spawnOptions);
 
-    if (command.register) {
-      this.vars[command.register] = result.stdout;
+    if (command.register && result.stdout) {
+      const out = result.stdout.toString().trim();
+      logger.info(`Saved ${out} to ${command.register}`);
+      this.vars[command.register] = out;
     }
 
     if(this.shouldExecutionContinue(result, command)) {

--- a/test/commands-from-yaml.spec.js
+++ b/test/commands-from-yaml.spec.js
@@ -158,7 +158,7 @@ describe('Given a YAML file run command execution', () => {
         executable: 'twoface',
         args: '-H consul.dun.fh -b blue -g green peek'.split(' '),
         options: {
-          stdio: 'inherit'
+          stdio: 'pipe'
         }
       },
       {


### PR DESCRIPTION
Switched stdio of processes requiring the register option to pipe, as register was not passing across the result of commands as expected. 

Paired with: Jae
