### PR TITLE
Added retry function with no of attempts and delay in seconds

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "js-yaml": "^3.5.5",
     "lodash": "^4.6.1",
     "npm-run": "^3.0.0",
+    "sleep": "^3.0.1",
     "winston": "^2.2.0"
   },
   "devDependencies": {

--- a/test/commands-from-yaml.spec.js
+++ b/test/commands-from-yaml.spec.js
@@ -171,4 +171,51 @@ describe('Given a YAML file run command execution', () => {
       expect(spawnSyncStub).to.have.been.calledWith(expected.executable, expected.args);
     });
   })
+
+  it ('Should retry a command if it fails', () => {
+    const test = {
+      key: 'retry',
+      cmdArgs: [],
+      expected: {
+        executable: 'echo',
+        args: 'test_retry'.split(' '),
+      }
+    };
+
+    spawnSyncStub.onFirstCall().returns({
+      status: 1,
+      error: new Error("Test Error")
+    });
+    spawnSyncStub.onSecondCall().returns({
+      status: 0
+    });
+
+    run(test.key, test.cmdArgs, {filepath:filename});
+    expect(spawnSyncStub).to.have.been.calledWith(test.expected.executable, test.expected.args);
+    expect(spawnSyncStub).to.have.been.calledTwice;
+  });
+
+  it ('Should throw if it exceeds the maximum number of retries', () => {
+    const test = {
+      key: 'retry',
+      cmdArgs: [],
+      expected: {
+        executable: 'echo',
+        args: 'test_retry'.split(' '),
+      }
+    };
+
+    spawnSyncStub.onFirstCall().returns({
+      status: 1,
+      error: new Error("Test Error")
+    });
+    spawnSyncStub.onSecondCall().returns({
+      status: 1,
+      error: new Error("Test Error")
+    });
+
+    expect(() => run(test.key, test.cmdArgs, {filepath:filename})).to.throw();
+    expect(spawnSyncStub).to.have.been.calledWith(test.expected.executable, test.expected.args);
+    expect(spawnSyncStub).to.have.been.calledTwice;
+  });
 });

--- a/test/test.usher.yml
+++ b/test/test.usher.yml
@@ -31,3 +31,8 @@ tasks:
     - cmd: twoface -H <%=host%> -b <%=blue_tag%> -g <%=green_tag%> peek
       register: deploy_target
     - cmd: docker -H <%=host%> run --name <%=deploy_target%> --rm <%=registry%>/<%=image%>:<%=version%>
+  retry:
+    - cmd: echo test_retry
+      retry:
+        attempts: 2
+        delay: 0.01


### PR DESCRIPTION
- For retrying things like smoke tests which can be expected to fail at first if the service is not ready
- https://trello.com/c/tOx1WF1Z/269-titan-finalise-ci-pipeline
