### PR TITLE
Sleep optional dependecy

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,8 +27,10 @@
     "js-yaml": "^3.5.5",
     "lodash": "^4.6.1",
     "npm-run": "^3.0.0",
-    "sleep": "^3.0.1",
     "winston": "^2.2.0"
+  },
+  "optionalDependencies": {
+    "sleep": "^3.0.1"
   },
   "devDependencies": {
     "chai": "^3.5.0",

--- a/src/modules/task-runner.js
+++ b/src/modules/task-runner.js
@@ -2,7 +2,16 @@
 
 const _ = require('lodash');
 const logger = require('winston');
-const sleep = require('sleep');
+
+const getOptionalSleep = () => {
+  try {
+    return require('sleep');
+  } catch (error) {
+    return null;
+  };
+};
+
+const sleep = getOptionalSleep();
 
 let spawnSync = require('npm-run').spawnSync;
 
@@ -51,9 +60,13 @@ class TaskRunner {
       return true;
     }
     if(this.shouldCommandRetry(command)) {
-      sleep.usleep(command.retry.delay * 1000000);
+      if (sleep) {
+        sleep.usleep(command.retry.delay * 1000000);
+      }
+
       return this.runCommand(command);
     }
+
     throw result.error;
   }
 


### PR DESCRIPTION
Wrapping require in a try catch and then null checking as the npm guide suggests. I have only wrapped the sleeping functionality which means that the reties will still happen. I can wrap the entire retry mechanic however if that makes more sense to do?
