### PR TITLE
Fix circular dependency

### DIFF
--- a/src/modules/get-task-config.js
+++ b/src/modules/get-task-config.js
@@ -1,0 +1,19 @@
+'use strict';
+
+const parser = require('js-yaml');
+const fs = require('fs');
+const _ = require('lodash');
+
+module.exports = (taskName, taskVars, opts) => {
+  const usherFile = opts.filepath || '.usher.yml';
+  const config = parser.safeLoad(fs.readFileSync(usherFile, 'utf8'));
+
+  if (!_.isArray(config.tasks[taskName])) {
+    throw new Error('Tasks should be array of commands');
+  }
+
+  return {
+    vars: _.merge(config.vars, taskVars),
+    task: config.tasks[taskName]
+  };
+};

--- a/src/modules/task-runner.js
+++ b/src/modules/task-runner.js
@@ -3,7 +3,7 @@
 const _ = require('lodash');
 const logger = require('winston');
 const snuze = require('snuze');
-let run = require('../run');
+const getTaskConfig = require('./get-task-config');
 
 let spawnSync = require('npm-run').spawnSync;
 
@@ -43,7 +43,11 @@ class TaskRunner {
 
   runTask(command) {
     logger.info(`Executing task : ${command.task} with vars ${JSON.stringify(command.vars)}`);
-    return run(command.task, command.vars, this.opts);
+
+    const taskConfig = getTaskConfig(command.task, command.vars, this.opts);
+    const taskRunner = new TaskRunner(taskConfig.task, taskConfig.vars, this.opts);
+
+    return taskRunner.execute();
   }
 
   runCommand(command) {

--- a/src/run.js
+++ b/src/run.js
@@ -1,35 +1,13 @@
 'use strict';
 
-const parser = require('js-yaml');
-const fs = require('fs');
-const _ = require('lodash');
 let TaskRunner = require('./modules/task-runner');
-
-function getTaskConfig(taskName, taskVars, opts) {
-  const usherFile = opts.filepath || '.usher.yml';
-  const config = parser.safeLoad(fs.readFileSync(usherFile, 'utf8'));
-
-  let parsedVars;
-  if (Array.isArray(taskVars)) {
-    const splitVars = _.map(taskVars, a => a.split('='));
-    parsedVars = _.fromPairs(splitVars);
-  }
-  else {
-    parsedVars = taskVars;
-  }
-
-  if (!_.isArray(config.tasks[taskName])) {
-    throw new Error('Tasks should be array of commands');
-  }
-
-  return {
-    vars: _.merge(config.vars, parsedVars),
-    task: config.tasks[taskName]
-  };
-}
+const _ = require('lodash');
+const getTaskConfig = require('./modules/get-task-config');
 
 module.exports = (taskName, taskVars, opts) => {
-  const taskConfig = getTaskConfig(taskName, taskVars, opts);
+  const splitVars = _.map(taskVars, a => a.split('='));
+  const parsedVars = _.fromPairs(splitVars);
+  const taskConfig = getTaskConfig(taskName, parsedVars, opts);
   const taskRunner = new TaskRunner(taskConfig.task, taskConfig.vars, opts);
 
   taskRunner.execute();

--- a/test/commands-from-yaml.spec.js
+++ b/test/commands-from-yaml.spec.js
@@ -1,13 +1,15 @@
-"use strict";
+/* global describe it beforeEach */
+/* eslint no-underscore-dangle: "off", no-unused-expressions: "off" */
+'use strict';
 
-const logger    = require('winston');
+const logger = require('winston');
 logger.level = 'none';
-const chai      = require('chai');
-const expect    = chai.expect;
-const sinon     = require('sinon');
+const chai = require('chai');
+const expect = chai.expect;
+const sinon = require('sinon');
 const sinonChai = require('sinon-chai');
-const rewire    = require('rewire');
-const _         = require('lodash');
+const rewire = require('rewire');
+const _ = require('lodash');
 
 let taskRunner = rewire('../src/modules/task-runner');
 let run = rewire('../src/run');
@@ -21,107 +23,103 @@ describe('Given a YAML file run command execution', () => {
       key: 'build',
       cmdArgs: ['version=latest'],
       expected: [{
-          executable: 'docker',
-          args: 'build --force-rm -t docker-registry.dun.fh/findmypast/usher:latest .'.split(' '),
+        executable: 'docker',
+        args: 'build --force-rm -t docker-registry.dun.fh/findmypast/usher:latest .'.split(' ')
       }]
     },
     {
       key: 'build',
       cmdArgs: ['version=latest', 'image=usher-test'],
       expected: [{
-          executable: 'docker',
-          args: 'build --force-rm -t docker-registry.dun.fh/usher-test:latest .'.split(' '),
+        executable: 'docker',
+        args: 'build --force-rm -t docker-registry.dun.fh/usher-test:latest .'.split(' ')
       }]
     },
     {
       key: 'publish',
       cmdArgs: ['version=latest', 'user=neil', 'password=password', 'email=ncrawford@findmypast.com'],
       expected: [{
-          executable: 'docker',
-          args: 'run --name usher-publisher --rm docker-registry.dun.fh/findmypast/usher:latest npm run publish-to-npm'.split(' '),
-          options: {
-            env: _.merge({
-              NPM_USER: 'neil',
-              NPM_PASSWORD: 'password',
-              NPM_EMAIL: 'ncrawford@findmypast.com'
-            }, process.env),
-            stdio: 'inherit'
-          }
+        executable: 'docker',
+        args: 'run --name usher-publisher --rm docker-registry.dun.fh/findmypast/usher:latest npm run publish-to-npm'.split(' '),
+        options: {
+          env: _.merge({
+            NPM_USER: 'neil',
+            NPM_PASSWORD: 'password',
+            NPM_EMAIL: 'ncrawford@findmypast.com'
+          }, process.env),
+          stdio: 'inherit'
+        }
       }]
     },
     {
       key: 'build_seq',
       cmdArgs: ['version=latest'],
       expected: [
-      {
-        executable: 'docker',
-        args: 'rm -f findmypast/usher-local'.split(' '),
-      },
-      {
-        executable: 'docker',
-        args: 'build --force-rm -t docker-registry.dun.fh/findmypast/usher:latest .'.split(' '),
-      }]
+        {
+          executable: 'docker',
+          args: 'rm -f findmypast/usher-local'.split(' ')
+        },
+        {
+          executable: 'docker',
+          args: 'build --force-rm -t docker-registry.dun.fh/findmypast/usher:latest .'.split(' ')
+        }]
     },
     {
       key: 'build_seq_ignore_errors',
       cmdArgs: ['version=latest'],
       expected: [
-      {
-        executable: 'docker',
-        args: 'rm -f findmypast/usher-local'.split(' '),
-      },
-      {
-        executable: 'docker',
-        args: 'build --force-rm -t docker-registry.dun.fh/findmypast/usher:latest .'.split(' '),
-      }]
+        {
+          executable: 'docker',
+          args: 'rm -f findmypast/usher-local'.split(' ')
+        },
+        {
+          executable: 'docker',
+          args: 'build --force-rm -t docker-registry.dun.fh/findmypast/usher:latest .'.split(' ')
+        }]
     },
     {
       key: 'run_task',
       cmdArgs: [],
       expected: [{
-          executable: 'docker',
-          args: 'build --force-rm -t docker-registry.dun.fh/findmypast/usher:task .'.split(' '),
+        executable: 'docker',
+        args: 'build --force-rm -t docker-registry.dun.fh/findmypast/usher:task .'.split(' ')
       }]
     }
   ];
 
   let spawnSyncStub = sinon.stub();
   taskRunner.__set__({
-    spawnSync:  spawnSyncStub
+    spawnSync: spawnSyncStub
   });
 
   run.__set__({
     TaskRunner: taskRunner
   });
 
-  taskRunner.__set__({
-    run: run
-  });
-
   beforeEach(() => {
     spawnSyncStub.reset();
     spawnSyncStub.returns({
       status: 0});
-  })
+  });
 
   tests.forEach( test =>
     it(`should execute task ${test.key} with command line vars ${test.cmdArgs.join(' ')}`, () => {
-      run(test.key, test.cmdArgs, {filepath:filename})
+      run(test.key, test.cmdArgs, {filepath: filename});
       _.map(test.expected, expected => {
         expect(spawnSyncStub).to.have.been.calledWith(expected.executable, expected.args);
-      })
+      });
     }));
 
-  it(`Should pass through environment variables merged with the parent environment`, () => {
+  it('Should pass through environment variables merged with the parent environment', () => {
     let test = _.find(tests, {key: 'publish'});
 
-    run(test.key, test.cmdArgs, {filepath:filename});
+    run(test.key, test.cmdArgs, {filepath: filename});
     _.map(test.expected, expected => {
       expect(spawnSyncStub).to.have.been.calledWith(expected.executable, expected.args, expected.options);
     });
   });
 
-  it(`Should not continue to execute a sequence of commands when an error is returned`, ()=> {
+  it('Should not continue to execute a sequence of commands when an error is returned', ()=> {
     const expectedError = new Error('Test error!');
     spawnSyncStub.returns({
       status: 1,
@@ -131,12 +129,12 @@ describe('Given a YAML file run command execution', () => {
     const test = _.find(tests, {key: 'build_seq'});
     const expected = test.expected[0];
 
-    expect(() => run(test.key, test.cmdArgs, {filepath:filename})).to.throw(expectedError);
+    expect(() => run(test.key, test.cmdArgs, {filepath: filename})).to.throw(expectedError);
     expect(spawnSyncStub).to.have.been.calledWith(expected.executable, expected.args);
     expect(spawnSyncStub).to.have.been.calledOnce;
-  })
+  });
 
-  it(`Should continue to execute a sequence of commands when an error is returned on a command with ignore_errors: true`, ()=> {
+  it('Should continue to execute a sequence of commands when an error is returned on a command with ignore_errors: true', ()=> {
     spawnSyncStub.returns({
       status: 1,
       error: new Error('Test error!')
@@ -144,33 +142,33 @@ describe('Given a YAML file run command execution', () => {
 
     let test = _.find(tests, {key: 'build_seq_ignore_errors'});
 
-    run(test.key, test.cmdArgs, {filepath:filename});
+    run(test.key, test.cmdArgs, {filepath: filename});
     _.map(test.expected, expected => {
       expect(spawnSyncStub).to.have.been.calledWith(expected.executable, expected.args);
-    })
-  })
+    });
+  });
 
-  it ('Should save the result of a command to a variable', () => {
+  it('Should save the result of a command to a variable', () => {
     const expectedDeployTarget = 'green';
 
     const test = {
       key: 'pass_value_to_next_command',
       cmdArgs: ['version=latest'],
       expected: [
-      {
-        executable: 'twoface',
-        args: '-H consul.dun.fh -b blue -g green peek'.split(' '),
-        options: {
-          stdio: 'pipe'
-        }
-      },
-      {
-        executable: 'docker',
-        args: `-H consul.dun.fh run --name ${expectedDeployTarget} --rm docker-registry.dun.fh/findmypast/usher:latest`.split(' '),
-        options: {
-          stdio: 'inherit'
-        }
-      }]
+        {
+          executable: 'twoface',
+          args: '-H consul.dun.fh -b blue -g green peek'.split(' '),
+          options: {
+            stdio: 'pipe'
+          }
+        },
+        {
+          executable: 'docker',
+          args: `-H consul.dun.fh run --name ${expectedDeployTarget} --rm docker-registry.dun.fh/findmypast/usher:latest`.split(' '),
+          options: {
+            stdio: 'inherit'
+          }
+        }]
     };
 
     spawnSyncStub.returns({
@@ -178,55 +176,55 @@ describe('Given a YAML file run command execution', () => {
       stdout: expectedDeployTarget
     });
 
-    run(test.key, test.cmdArgs, {filepath:filename});
+    run(test.key, test.cmdArgs, {filepath: filename});
     _.map(test.expected, expected => {
       expect(spawnSyncStub).to.have.been.calledWith(expected.executable, expected.args);
     });
-  })
+  });
 
-  it ('Should retry a command if it fails', () => {
+  it('Should retry a command if it fails', () => {
     const test = {
       key: 'retry',
       cmdArgs: [],
       expected: {
         executable: 'echo',
-        args: 'test_retry'.split(' '),
+        args: 'test_retry'.split(' ')
       }
     };
 
     spawnSyncStub.onFirstCall().returns({
       status: 1,
-      error: new Error("Test Error")
+      error: new Error('Test Error')
     });
     spawnSyncStub.onSecondCall().returns({
       status: 0
     });
 
-    run(test.key, test.cmdArgs, {filepath:filename});
+    run(test.key, test.cmdArgs, {filepath: filename});
     expect(spawnSyncStub).to.have.been.calledWith(test.expected.executable, test.expected.args);
     expect(spawnSyncStub).to.have.been.calledTwice;
   });
 
-  it ('Should throw if it exceeds the maximum number of retries', () => {
+  it('Should throw if it exceeds the maximum number of retries', () => {
     const test = {
       key: 'retry',
       cmdArgs: [],
       expected: {
         executable: 'echo',
-        args: 'test_retry'.split(' '),
+        args: 'test_retry'.split(' ')
       }
     };
 
     spawnSyncStub.onFirstCall().returns({
       status: 1,
-      error: new Error("Test Error")
+      error: new Error('Test Error')
     });
     spawnSyncStub.onSecondCall().returns({
       status: 1,
-      error: new Error("Test Error")
+      error: new Error('Test Error')
     });
 
-    expect(() => run(test.key, test.cmdArgs, {filepath:filename})).to.throw();
+    expect(() => run(test.key, test.cmdArgs, {filepath: filename})).to.throw();
     expect(spawnSyncStub).to.have.been.calledWith(test.expected.executable, test.expected.args);
     expect(spawnSyncStub).to.have.been.calledTwice;
   });


### PR DESCRIPTION
- The way subtasks had been implemented led to a circular dependency
- Informative note: nodeJS doesn't error on circular dependencies, it just returns an empty object which means if you mock out the dependency for tests the error can't be caught with automated testing
- So JS is bad and should feel bad
- https://trello.com/c/0etHCS0I/327-usher-run-tasks-from-other-tasks
