### PR TITLE
Swapping shell task from `child_process` to `npm-run`

### DIFF
--- a/src/v2/tasks/shell.js
+++ b/src/v2/tasks/shell.js
@@ -2,7 +2,7 @@
 
 const Promise = require('bluebird');
 const _ = require('lodash');
-const exec = require('child_process').exec;
+const exec = require('npm-run').exec;
 const split = require('split');
 
 const ACCEPTED_OPTIONS = [

--- a/src/v2/tasks/shell.spec.js
+++ b/src/v2/tasks/shell.spec.js
@@ -22,7 +22,7 @@ describe('tasks/shell', function() {
   };
   const Logger = mocks.Logger;
   before(function() {
-    mockery.registerMock('child_process', child);
+    mockery.registerMock('npm-run', child);
 
     sut = require('./shell');
   });


### PR DESCRIPTION
- usher can use locally installed packages like npm scripts 

`usher run lint` will now work if the task is `eslint` in usher without `eslint` being globally installed